### PR TITLE
Content options tunning

### DIFF
--- a/packages/bundler/tests/jest/multiple-files/expected/second.html
+++ b/packages/bundler/tests/jest/multiple-files/expected/second.html
@@ -1,6 +1,6 @@
 <!--
-	@stylify-files[second/nette.latte second/symfony.twig second/vue.vue /second/html.html]
-	@stylify-pregenerate[content:^second^]
+	@stylify-files second/nette.latte second/symfony.twig second/vue.vue /second/html.html /@stylify-files
+	@stylify-pregenerate content:^second^ /@stylify-pregenerate
 -->
 
 <div class="_d23dl"></div>

--- a/packages/bundler/tests/jest/multiple-files/expected/second/html.html
+++ b/packages/bundler/tests/jest/multiple-files/expected/second/html.html
@@ -1,3 +1,3 @@
-<!-- @stylify-pregenerate[content:^Excluded^] -->
+<!-- @stylify-pregenerate content:^Excluded^ /@stylify-pregenerate -->
 
 <div class="_5jc7t"></div>

--- a/packages/bundler/tests/jest/multiple-files/expected/second/nette.latte
+++ b/packages/bundler/tests/jest/multiple-files/expected/second/nette.latte
@@ -1,3 +1,3 @@
-{* @stylify-pregenerate[content:^Nette^] *}
+{* @stylify-pregenerate content:^Nette^ /@stylify-pregenerate *}
 
 <div n:class="'_h1et7 _h1fr8', true ? '_h1et7 _h1fr8'"></div>

--- a/packages/bundler/tests/jest/multiple-files/expected/second/symfony.twig
+++ b/packages/bundler/tests/jest/multiple-files/expected/second/symfony.twig
@@ -1,3 +1,3 @@
-{# @stylify-pregenerate[content:^Symfony^] #}
+{# @stylify-pregenerate content:^Symfony^ /@stylify-pregenerate #}
 
 <div class="{% if true %}_h1et7{% else %} _h1fr8{% endif %}"></div>

--- a/packages/bundler/tests/jest/multiple-files/expected/second/vue.vue
+++ b/packages/bundler/tests/jest/multiple-files/expected/second/vue.vue
@@ -1,10 +1,10 @@
-<!-- @stylify-pregenerate[content:^Vue^] -->
+<!-- @stylify-pregenerate content:^Vue^ /@stylify-pregenerate -->
 
 <template>
 	<div v-bind:class="{ '_h1gp9': true }"></div>
 </template>
 
 <script>
-	// @stylify-pregenerate[content:^vue-script^]
-	// @stylify-files[vuejs/component.vue]
+	// @stylify-pregenerate content:^vue-script^ /@stylify-pregenerate
+	// @stylify-files vuejs/component.vue /@stylify-files
 </script>

--- a/packages/bundler/tests/jest/multiple-files/expected/second/vuejs/component.vue
+++ b/packages/bundler/tests/jest/multiple-files/expected/second/vuejs/component.vue
@@ -1,4 +1,4 @@
-<!-- @stylify-pregenerate[content:^vuejs__component^] -->
+<!-- @stylify-pregenerate content:^vuejs__component^ /@stylify-pregenerate -->
 
 <template>
 	<div v-bind:class="{ '_h3cr9': true }"></div>

--- a/packages/bundler/tests/jest/multiple-files/input/second.html
+++ b/packages/bundler/tests/jest/multiple-files/input/second.html
@@ -1,6 +1,6 @@
 <!--
-	@stylify-files[second/nette.latte second/symfony.twig second/vue.vue /second/html.html]
-	@stylify-pregenerate[content:^second^]
+	@stylify-files second/nette.latte second/symfony.twig second/vue.vue /second/html.html /@stylify-files
+	@stylify-pregenerate content:^second^ /@stylify-pregenerate
 -->
 
 <div class="color:yellow"></div>

--- a/packages/bundler/tests/jest/multiple-files/input/second/html.html
+++ b/packages/bundler/tests/jest/multiple-files/input/second/html.html
@@ -1,3 +1,3 @@
-<!-- @stylify-pregenerate[content:^Excluded^] -->
+<!-- @stylify-pregenerate content:^Excluded^ /@stylify-pregenerate -->
 
 <div class="color:purple"></div>

--- a/packages/bundler/tests/jest/multiple-files/input/second/nette.latte
+++ b/packages/bundler/tests/jest/multiple-files/input/second/nette.latte
@@ -1,3 +1,3 @@
-{* @stylify-pregenerate[content:^Nette^] *}
+{* @stylify-pregenerate content:^Nette^ /@stylify-pregenerate *}
 
 <div n:class="'font-size:24px font-size:25px', true ? 'font-size:24px font-size:25px'"></div>

--- a/packages/bundler/tests/jest/multiple-files/input/second/symfony.twig
+++ b/packages/bundler/tests/jest/multiple-files/input/second/symfony.twig
@@ -1,3 +1,3 @@
-{# @stylify-pregenerate[content:^Symfony^] #}
+{# @stylify-pregenerate content:^Symfony^ /@stylify-pregenerate #}
 
 <div class="{% if true %}font-size:24px{% else %} font-size:25px{% endif %}"></div>

--- a/packages/bundler/tests/jest/multiple-files/input/second/vue.vue
+++ b/packages/bundler/tests/jest/multiple-files/input/second/vue.vue
@@ -1,10 +1,10 @@
-<!-- @stylify-pregenerate[content:^Vue^] -->
+<!-- @stylify-pregenerate content:^Vue^ /@stylify-pregenerate -->
 
 <template>
 	<div v-bind:class="{ 'font-size:26px': true }"></div>
 </template>
 
 <script>
-	// @stylify-pregenerate[content:^vue-script^]
-	// @stylify-files[vuejs/component.vue]
+	// @stylify-pregenerate content:^vue-script^ /@stylify-pregenerate
+	// @stylify-files vuejs/component.vue /@stylify-files
 </script>

--- a/packages/bundler/tests/jest/multiple-files/input/second/vuejs/component.vue
+++ b/packages/bundler/tests/jest/multiple-files/input/second/vuejs/component.vue
@@ -1,4 +1,4 @@
-<!-- @stylify-pregenerate[content:^vuejs__component^] -->
+<!-- @stylify-pregenerate content:^vuejs__component^ /@stylify-pregenerate -->
 
 <template>
 	<div v-bind:class="{ 'font-size:48px': true }"></div>

--- a/packages/bundler/tests/jest/normalized-path/input/index.html
+++ b/packages/bundler/tests/jest/normalized-path/input/index.html
@@ -1,5 +1,5 @@
 <!--
-	@stylify-files[ .\\nested\\dir\\part.html ]
+	@stylify-files  .\\nested\\dir\\part.html  /@stylify-files
 -->
 
 <div class="font-size:24px"></div>

--- a/packages/bundler/tests/jest/single-file/expected/second.html
+++ b/packages/bundler/tests/jest/single-file/expected/second.html
@@ -1,5 +1,5 @@
 <!--
-	@stylify-components[{
+	@stylify-components
 		'profiler-extension': `
 			box-sizing:border-box
 			border-left:1px__solid__#555
@@ -50,8 +50,9 @@
 			color:#aaa
 		`,
 		'profiler-extension__button-label': 'line-height:1'
-	}]
-	@stylify-pregenerate[
+	/@stylify-components
+
+	@stylify-pregenerate
 		border-top:1px__solid__#444
 		background-color:#333
 		bottom:0
@@ -81,5 +82,5 @@
 		profiler-extension__link
 		profiler-extension__button-icon
 		profiler-extension__button-label
-	]
+	/@stylify-pregenerate
 -->

--- a/packages/bundler/tests/jest/single-file/input/index.html
+++ b/packages/bundler/tests/jest/single-file/input/index.html
@@ -1,5 +1,5 @@
 <!--
-	@stylify-components[{
+	@stylify-components
 		'profiler-extension': `
 			box-sizing:border-box
 			border-left:1px__solid__#555
@@ -50,8 +50,8 @@
 			color:#aaa
 		`,
 		'profiler-extension__button-label': 'line-height:1'
-	}]
-	@stylify-pregenerate[
+	/@stylify-components
+	@stylify-pregenerate
 		border-top:1px__solid__#444
 		background-color:#333
 		bottom:0
@@ -81,5 +81,5 @@
 		profiler-extension__link
 		profiler-extension__button-icon
 		profiler-extension__button-label
-	]
+	/@stylify-pregenerate
 -->

--- a/packages/bundler/tests/jest/single-file/input/second.html
+++ b/packages/bundler/tests/jest/single-file/input/second.html
@@ -1,5 +1,5 @@
 <!--
-	@stylify-components[{
+	@stylify-components
 		'profiler-extension': `
 			box-sizing:border-box
 			border-left:1px__solid__#555
@@ -50,8 +50,9 @@
 			color:#aaa
 		`,
 		'profiler-extension__button-label': 'line-height:1'
-	}]
-	@stylify-pregenerate[
+	/@stylify-components
+
+	@stylify-pregenerate
 		border-top:1px__solid__#444
 		background-color:#333
 		bottom:0
@@ -81,5 +82,5 @@
 		profiler-extension__link
 		profiler-extension__button-icon
 		profiler-extension__button-label
-	]
+	/@stylify-pregenerate
 -->

--- a/packages/stylify/tests/jest/combined-pages/expected/index.html
+++ b/packages/stylify/tests/jest/combined-pages/expected/index.html
@@ -1,5 +1,5 @@
-<!-- @stylify-pregenerate[font-size:123px line-height:123px color:#fff color:#888]  -->
-<!-- @stylify-pregenerate[font-size:456px line-height:456px color:yellow]  -->
+<!-- @stylify-pregenerate font-size:123px line-height:123px color:#fff color:#888 /@stylify-pregenerate -->
+<!-- @stylify-pregenerate font-size:456px line-height:456px color:yellow /@stylify-pregenerate  -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/packages/stylify/tests/jest/combined-pages/input/index.html
+++ b/packages/stylify/tests/jest/combined-pages/input/index.html
@@ -1,5 +1,5 @@
-<!-- @stylify-pregenerate[font-size:123px line-height:123px color:#fff color:#888]  -->
-<!-- @stylify-pregenerate[font-size:456px line-height:456px color:yellow]  -->
+<!-- @stylify-pregenerate font-size:123px line-height:123px color:#fff color:#888 /@stylify-pregenerate -->
+<!-- @stylify-pregenerate font-size:456px line-height:456px color:yellow /@stylify-pregenerate  -->
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
- Syntax change: `@stylify-<option name>[<content>]` to `@stylify-<option name><content>/@stylify-<option-name>`
```
@stylify-pregenerate content:^second^ /@stylify-pregenerate
```
- Stylify components, variables, plainSelectors have now the same syntax as javascript objects instead of json syntax
```
	@stylify-components
		button: `
                       padding:24px
                       background:steelblue
                       color:#fff
                       display:inline-block
		`
	/@stylify-components
```
- Options can now contain brackets

